### PR TITLE
チーム開発、Basic認証修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
 


### PR DESCRIPTION
# What
Basic認証で本番環境のみBasic認証が出来るようにした。
# Why
ローカルの確認でいちいちパスワードを入力していたら時間が無駄になるため。