### PR TITLE
itemsテーブルカラム名変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 |saler_id|integer|null: false|
 |buyer_id|integer|
 |detail|text|null: false|
+|situation|string|null: false|
 |brand_id|references|foreign_key: true|
 |category_id|references|foreign_key: true|
 

--- a/db/migrate/20190810085106_rename_titre_column_to_items.rb
+++ b/db/migrate/20190810085106_rename_titre_column_to_items.rb
@@ -1,6 +1,6 @@
 class RenameTitreColumnToItems < ActiveRecord::Migration[5.2]
   def change
-    rename_column :items, :seller, :seller_id
+    rename_column :items, :seler, :seler_id
     rename_column :items, :buyer,  :buyer_id
   end
 end

--- a/db/migrate/20190810085106_rename_titre_column_to_items.rb
+++ b/db/migrate/20190810085106_rename_titre_column_to_items.rb
@@ -1,0 +1,6 @@
+class RenameTitreColumnToItems < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :items, :seller, :seller_id
+    rename_column :items, :buyer,  :buyer_id
+  end
+end


### PR DESCRIPTION
WHAT
取引の際のusersテーブルとitemsテーブルの中間テーブルであるtradeテーブルを無くし、
seller→seller_id
buyer→buyer_id
に変更する。

WHY
実装の方向性が決まったため。