### PR TITLE
アソシエーション設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ end
 
 gem 'haml-rails'
 gem 'font-awesome-rails'
+gem 'seed-fu', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    seed-fu (2.3.9)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -272,6 +275,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.3)
   sass-rails (~> 5.0)
+  seed-fu (~> 2.3)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
-  has_many :users, through: :trades
   has_many :photos
   belongs_to :brand
   belongs_to :category
+  belongs_to :saler, class_name: "User"
+  belongs_to :buyer, class_name: "User"
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,11 @@ class User < ApplicationRecord
 
   has_one :credit
   accepts_nested_attributes_for :credit
+
+  # 購入した商品 →bought_items。itemsテーブルの「buyer_id」(購入者)とuserの「id」と紐かせる
+  has_many :bought_items, foreign_key: "buyer_id", class_name: "Item"
+  # 現在売っている」商品 →saling_items。
+  # buyer_idがNULLのとき →:saling_items, -> { where("buyer_id is NULL") }(SQL文)
+  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "saler_id", class_name: "Item"
+  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "saler_id", class_name: "Item"
 end

--- a/db/fixtures/item.rb
+++ b/db/fixtures/item.rb
@@ -1,0 +1,74 @@
+User.seed do |s|
+  s.id = 1
+  s.nickname = "松本"
+  s.gender = "男性"
+  s.introduction = "よろしく"
+  s.email = "test@gmail.com"
+  s.password = "pppppp"
+end
+
+User.seed do |s|
+  s.id = 2
+  s.nickname = "櫻井"
+  s.gender = "男性"
+  s.introduction = "よろしく"
+  s.email = "test2@gmail.com"
+  s.password = "pppppp"
+end
+
+User.seed do |s|
+  s.id = 3
+  s.nickname = "大野"
+  s.gender = "男性"
+  s.introduction = "よろしく"
+  s.email = "test3@gmail.com"
+  s.password = "pppppp"
+end
+
+Item.seed do |s|
+  s.id = 1
+  s.name = "小説"
+  s.price = 400
+  s.size =
+  s.status = 0
+  s.pay_way = 0
+  s.deliver_way = 0
+  s.deliver_data = 0
+  s.deliver_fee = 0
+  s.saler_id = 1
+  s.buyer_id = 2
+  s.detail = "面白いです。"
+  s.situation = "売り切れ"
+end
+
+Item.seed do |s|
+  s.id = 2
+  s.name = "ズボン"
+  s.price = 1500
+  s.size = "M"
+  s.status = 0
+  s.pay_way = 0
+  s.deliver_way = 0
+  s.deliver_data = 0
+  s.deliver_fee = 0
+  s.saler_id = 2
+  s.buyer_id = 3
+  s.detail = "一度しか履いていません。"
+  s.situation = "販売中"
+end
+
+Item.seed do |s|
+  s.id = 3
+  s.name = "シャツ"
+  s.price = 1000
+  s.size = "S"
+  s.status = 0
+  s.pay_way = 0
+  s.deliver_way = 0
+  s.deliver_data = 0
+  s.deliver_fee = 0
+  s.saler_id = 3
+  s.buyer_id = ""
+  s.detail = "一度も着ていません。"
+  s.situation = "販売中"
+end

--- a/db/migrate/20190811024720_create_categories.rb
+++ b/db/migrate/20190811024720_create_categories.rb
@@ -1,0 +1,8 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string   :name,null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_10_103158) do
+ActiveRecord::Schema.define(version: 2019_08_11_024720) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,12 @@ ActiveRecord::Schema.define(version: 2019_08_10_103158) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_brands_on_item_id"
+  end
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "credits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# WHAT
gem 'seed-fu', '~> 2.3'を導入する。
itemsテーブルとusersテーブルに仮のデータを入れる

itemsテーブルのsaler_idとbuyer_idがusersテーブルからデータのやり取りができるようにするアソシエーションを組む。

Userモデルで「買った商品」「現在売っている商品」「既に売った商品」を取り出せるようにするアソシエーションを組む。

ついでにcategorisモデルを生成。

# WHY
仮のデータがないとrails cでテスト出来ないためseed-fuを導入


# P.S.
55期の皆さんはbuyersテーブルを作って、中間テーブルではないですがitemsテーブルとusersとそれぞれアソシエーションを組んでいるようですがこのやり方で今後、想定できる不都合はありますでしょうか。