### PR TITLE
Addancesty to Categoriesの削除

### DIFF
--- a/db/migrate/20190812060306_add_ancesty_to_categories.rb
+++ b/db/migrate/20190812060306_add_ancesty_to_categories.rb
@@ -1,5 +1,0 @@
-class AddAncestyToCategories < ActiveRecord::Migration[5.2]
-  def change
-    change_column :categories, :ancestry, :string
-  end
-end


### PR DESCRIPTION
# What
Addancesty to Categoriesの削除

# Why
downになっているAddancesty to Categoriesの削除をし、他のマイグレーションを読み込むため