### PR TITLE
Payjp after get token

### DIFF
--- a/app/assets/javascripts/token.js
+++ b/app/assets/javascripts/token.js
@@ -11,7 +11,6 @@ document.addEventListener(
           exp_month: document.getElementById("exp_month").value,
           exp_year: document.getElementById("exp_year").value
         }; //入力されたデータを取得します。
-        console.log(card);
         Payjp.createToken(card, (status, response) => {
           if (status === 200) { //成功した場合
             $("#card_number").removeAttr("name");
@@ -21,8 +20,8 @@ document.addEventListener(
             $("#card_token").append(
               $('<input type="hidden" name="payjp-token">').val(response.id)
             );
-            // document.inputForm.submit();
-            $("#new_user")[0].submit();
+            document.inputForm.submit();
+            // $("#new_user")[0].submit();
             alert("登録が完了しました"); //確認用。あとで消す。
           } else {
             alert("カード情報が正しくありません。"); //確認用。あとで消す。

--- a/app/assets/javascripts/token.js
+++ b/app/assets/javascripts/token.js
@@ -10,9 +10,9 @@ document.addEventListener(
           cvc: document.getElementById("cvc").value,
           exp_month: document.getElementById("exp_month").value,
           exp_year: document.getElementById("exp_year").value
-        }; //入力されたデータを取得します。
+        }; // 入力されたデータを取得。
         Payjp.createToken(card, (status, response) => {
-          if (status === 200) { //成功した場合
+          if (status === 200) { // 成功した場合
             $("#card_number").removeAttr("name");
             $("#cvc").removeAttr("name");
             $("#exp_month").removeAttr("name");
@@ -21,10 +21,9 @@ document.addEventListener(
               $('<input type="hidden" name="payjp-token">').val(response.id)
             );
             document.inputForm.submit();
-            // $("#new_user")[0].submit();
-            alert("登録が完了しました"); //確認用。あとで消す。
+            alert("登録が完了しました");
           } else {
-            alert("カード情報が正しくありません。"); //確認用。あとで消す。
+            alert("カード情報が正しくありません。");
           }
         });
       });

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -4,7 +4,7 @@ class CreditsController < ApplicationController
 
 
   def new
-    card = Credit.where(user_id: current_user.id)
+    card = Credit.where(session[:email])
     redirect_to action: "show" if card.exists?
   end
 
@@ -14,29 +14,19 @@ class CreditsController < ApplicationController
     if params['payjp-token'].blank?
       redirect_to action:"new"
     else
-      customer = Payjp::Charge.create(
-      email: current_user.email, #セッションの中に入ってるの持ってきたりすんのかなあ？
-      card: params['payjp-token'],
-      metadata: {user_id: current_user.id}
+      customer = Payjp::Customer.create(
+      email: session[:email], #セッションの中に入ってるの持ってきたりすんのかなあ？
+      card: params['payjp-token']
       )
-      @card = Credit.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
-      if @card.save
-        redirect_to action: "show"
+      @user = User.new(session[:user_params])
+      @user.build_profile(session[:profile_attributes_after_delivery])
+      if @user.save
+        @card = Credit.create(user_id: @user.id, customer_id: customer.id, card_id: customer.default_card)
+        session[:id] = @user.id
+        redirect_to complete_signup_signup_index_path
       else
-        redirect_to action: "pay"
+        render '/signup/registration'
       end
-    end
-  end
-
-
-  def show #Creditのデータをpayjpに送り情報を取り出す
-    card = Credit.where(user_id: current_user.id).first
-    if card.blank?
-      redirect_to action: "new" 
-    else
-      Payjp.api_key = 'sk_test_1fc06ad12596877ef48d294c'
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      @default_card_information = customer.cards.retrieve(card.card_id)
     end
   end
 
@@ -52,9 +42,5 @@ class CreditsController < ApplicationController
   #   end
   #     redirect_to action: "new"
   # end
-
-
-
-
 
 end

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -9,15 +9,16 @@ class CreditsController < ApplicationController
   end
 
 
-  def pay #payjpとCreditのデータベース作成
+  def pay # payjpとCreditのdb作成
     Payjp.api_key = 'sk_test_1fc06ad12596877ef48d294c' # シークレットキー。流出厳禁。あとでcredentials.ymlに移す。
     if params['payjp-token'].blank?
       redirect_to action:"new"
     else
       customer = Payjp::Customer.create(
-      email: session[:email], #セッションの中に入ってるの持ってきたりすんのかなあ？
+      email: session[:email], 
       card: params['payjp-token']
       )
+      # ここでdbに保存する。signupの方でcreateしないのはredirect_toでPOSTに飛ばせないから。
       @user = User.new(session[:user_params])
       @user.build_profile(session[:profile_attributes_after_delivery])
       if @user.save
@@ -30,17 +31,17 @@ class CreditsController < ApplicationController
     end
   end
 
-
-  # def delete #PayjpとCreditデータベースを削除
-  #   card = Credit.where(user_id: current_user.id).first
-  #   if card.blank?
-  #   else
-  #     Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-  #     customer = Payjp::Customer.retrieve(card.customer_id)
-  #     customer.delete
-  #     card.delete
-  #   end
-  #     redirect_to action: "new"
-  # end
+#  # カード情報削除機能をつける時に使う。
+#   def delete #PayjpとCreditデータベースを削除
+#     card = Credit.where(user_id: current_user.id).first
+#     if card.blank?
+#     else
+#       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+#       customer = Payjp::Customer.retrieve(card.customer_id)
+#       customer.delete
+#       card.delete
+#     end
+#       redirect_to action: "new"
+#   end
 
 end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -56,22 +56,24 @@ class SignupController < ApplicationController
     @user.build_profile
     # @user.build_credit
   end
-  # # validation
-  # def save_pay_way_to_session
-  #   @user = User.new(session[:user_params])
-  #   @user.build_profile(session[:profile_attributes_after_delivery])
-  #   @user.build_credit(user_params[:credit_attributes])
-  #   render '/signup/pay_way' unless user_params[:credit_attributes][:card_no].present? && user_params[:credit_attributes][:validity_year].present? && user_params[:credit_attributes][:validity_month].present? && user_params[:credit_attributes][:security_no].present?
-  # end
+  # # # validation
+  # # def save_pay_way_to_session
+  # #   @user = User.new(session[:user_params])
+  # #   @user.build_profile(session[:profile_attributes_after_delivery])
+  # #   @user.build_credit(user_params[:credit_attributes])
+  # #   render '/signup/pay_way' unless user_params[:credit_attributes][:card_no].present? && user_params[:credit_attributes][:validity_year].present? && user_params[:credit_attributes][:validity_month].present? && user_params[:credit_attributes][:security_no].present?
+  # # end
 
 
 
 # save to DB
   def create
+    binding.pry
     @user = User.new(session[:user_params])
     @user.build_profile(session[:profile_attributes_after_delivery])
     # @user.build_credit(user_params[:credit_attributes])
     if @user.save
+      @card = Credit.new(user_id: @user.id, customer_id: customer.id, card_id: customer.default_card)
       session[:id] = @user.id
       redirect_to complete_signup_signup_index_path
     else
@@ -92,8 +94,6 @@ class SignupController < ApplicationController
       :email,
       :password, 
       :password_confirmation, 
-      :card_id,
-      :customer_id,
       profile_attributes: [:id, :family_name_kanji, :first_name_kanji, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, :postal_code, :prefectures, :city, :address1, :address2, :phone_number],
       # credit_attributes: [:id, :card_no, :validity_year, :validity_month, :security_no]
     )

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -3,7 +3,6 @@ class SignupController < ApplicationController
   before_action :save_registration_to_session, only: :sms_confirmation
   before_action :save_sms_confirmation_to_session, only: :delivery_address
   before_action :save_delivery_address_to_session, only: :pay_way
-  # before_action :save_pay_way_to_session, only: :create
 
   def index
   end
@@ -54,37 +53,24 @@ class SignupController < ApplicationController
   def pay_way
     @user = User.new
     @user.build_profile
-    # @user.build_credit
-  end
-  # # # validation
-  # # def save_pay_way_to_session
-  # #   @user = User.new(session[:user_params])
-  # #   @user.build_profile(session[:profile_attributes_after_delivery])
-  # #   @user.build_credit(user_params[:credit_attributes])
-  # #   render '/signup/pay_way' unless user_params[:credit_attributes][:card_no].present? && user_params[:credit_attributes][:validity_year].present? && user_params[:credit_attributes][:validity_month].present? && user_params[:credit_attributes][:security_no].present?
-  # # end
-
-
-
-# save to DB
-  def create
-    binding.pry
-    @user = User.new(session[:user_params])
-    @user.build_profile(session[:profile_attributes_after_delivery])
-    # @user.build_credit(user_params[:credit_attributes])
-    if @user.save
-      @card = Credit.new(user_id: @user.id, customer_id: customer.id, card_id: customer.default_card)
-      session[:id] = @user.id
-      redirect_to complete_signup_signup_index_path
-    else
-      render '/signup/registration'
-    end
   end
 
-# jump to complete
-  def complete_signup
-    sign_in User.find(session[:id]) unless user_signed_in?
-  end
+
+
+# # もう使わないけどセッションをまとめる時に思い出したいので残します。
+#   def create
+#     binding.pry
+#     @user = User.new(session[:user_params])
+#     @user.build_profile(session[:profile_attributes_after_delivery])
+#     if @user.save
+#       @card = Credit.new(user_id: @user.id, customer_id: customer.id, card_id: customer.default_card)
+#       session[:id] = @user.id
+#       redirect_to complete_signup_signup_index_path
+#     else
+#       render '/signup/registration'
+#     end
+#   end
+
 
 
   private
@@ -94,8 +80,7 @@ class SignupController < ApplicationController
       :email,
       :password, 
       :password_confirmation, 
-      profile_attributes: [:id, :family_name_kanji, :first_name_kanji, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, :postal_code, :prefectures, :city, :address1, :address2, :phone_number],
-      # credit_attributes: [:id, :card_no, :validity_year, :validity_month, :security_no]
+      profile_attributes: [:id, :family_name_kanji, :first_name_kanji, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, :postal_code, :prefectures, :city, :address1, :address2, :phone_number]
     )
   end
 

--- a/app/views/signup/delivery_address.html.haml
+++ b/app/views/signup/delivery_address.html.haml
@@ -74,7 +74,6 @@
 
 
 
-
     %footer.single-footer
       %ul.clearfix
         %li

--- a/app/views/signup/pay_way.html.haml
+++ b/app/views/signup/pay_way.html.haml
@@ -34,7 +34,7 @@
         .l-single-inner.registration-form1
           .l-single-content
 
-            = form_for @user, url: signup_index_path, method: :post do |f|
+            = form_for @user, url: pay_credits_path, method: :post, html: {name:"inputForm"} do |f|
               = hidden_field_tag :current_step, 'pay_way'
               -# = form_tag(pay_credit_index_path, method: :post, id: 'charge-form', name: "inputForm") do
               .each-forms
@@ -94,8 +94,8 @@
                 %p.security_no_detail
                   = fa_icon 'question-circle', class: 'icon icon-question-circle'
                   %a カードの裏面の番号とは？
-              .emptybox-payway
-              = submit_tag '次へ進む', url: "credit/show", method: :post, class: 'btn-default btn-red text-default__submit', id: "token_submit"
+              .emptybox-payway#card_token
+              = f.submit '次へ進む', class: 'btn-default btn-red text-default__submit', id: "token_submit"
 
 
 

--- a/app/views/signup/pay_way.html.haml
+++ b/app/views/signup/pay_way.html.haml
@@ -36,7 +36,6 @@
 
             = form_for @user, url: pay_credits_path, method: :post, html: {name:"inputForm"} do |f|
               = hidden_field_tag :current_step, 'pay_way'
-              -# = form_tag(pay_credit_index_path, method: :post, id: 'charge-form', name: "inputForm") do
               .each-forms
                 %div
                   %label カード番号

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,10 +28,6 @@ Rails.application.routes.draw do
   resources :users, only:[:index, :show] do
     # 新規登録
     collection do
-      # get 'sms_confirmation'
-      # get 'delivery_address'
-      # get 'pay_way'
-      # get 'complete_signup'
       get 'add_credit'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,10 +64,10 @@ Rails.application.routes.draw do
 
 
  # credits
- resources :credit, only: [:new, :show] do
+  resources :credits, only: [:new, :show] do
     collection do
-      post 'pay', to: 'credit#pay'
-      post 'show', to: 'credit#show'
+      post 'pay', to: 'credits#pay'
+      post 'show', to: 'credits#show'
     end
   end
 


### PR DESCRIPTION
## WHAT
payjpの導入
カード情報の登録とユーザーの紐付け
トークンの取得
新規登録でのユーザーの情報（session）とcustomer_id・card_idを同時にdbに保存

## WHY
ユーザーがクレジットカードを登録し、決済できるようにするため。
決済時になんどもカード情報を打ち込まずに済むように関連情報をdbに保存。