### PR TITLE
チーム開発　s3導入の修正

### DIFF
--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -4,7 +4,13 @@ class ImagesUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :fog
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -8,8 +8,8 @@ CarrierWave.configure do |config|
   config.fog_provider = 'fog/aws'
   config.fog_credentials = {
     provider: 'AWS',
-    aws_access_key_id: Rails.application.credentials.aws_access_key_id,
-    aws_secret_access_key: Rails.application.credentials.aws_secret_access_key,
+    aws_access_key_id: 'AWS_ACCESS_KEY_ID',
+    aws_secret_access_key: 'AWS_SECRET_ACCESS_KEY',
     region: 'ap-northeast-1'
   }
 


### PR DESCRIPTION
# What
s3の画像投稿でローカルに画像を保存できるようにuploader.rbに記述した。自動デプロイのエラー解消の為carrierwave.rbの記述編集をした。
# Why
ローカルで画像を保存出来るようにする為、自動デプロイのエラー解消の為
