### PR TITLE
 カテゴリーボックスの修正及び、エラーの解消

### DIFF
--- a/app/assets/stylesheets/category.scss
+++ b/app/assets/stylesheets/category.scss
@@ -52,6 +52,9 @@
     width:220px;
     height: 33px;
     line-height: 33px;
+    &:hover{
+      background-color: #eee;
+    }
   }
 }
 
@@ -70,5 +73,8 @@
     width:220px;
     height: 33px;
     line-height: 33px;
+    &:hover{
+      background-color: #eee;
+    }
   }
 } 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_item, only: [:show, :edit, :update, :destroy, :purchase_confirmation, :purchase]
-  before_action :set_categories, only: [:index, :new]
+  before_action :set_categories, only: [:index, :new, :show]
   
   require 'payjp'
   

--- a/app/views/home/_category.html.haml
+++ b/app/views/home/_category.html.haml
@@ -1,17 +1,17 @@
--# .header-category-list
--#   - @categories.each do |parent| 
--#     - if parent[:ancestry] == nil
--#       %ul.parent-wrap
--#         %li.parent
--#           %h4.parent-category
--#             = parent[:name]
--#           %ul.child-wrap
--#             - parent.children.each do |child|
--#               %li.child
--#                 %h4
--#                   = child[:name]
--#                 %ul.grand-child-wrap
--#                   - child.children.each do |grandchild|
--#                     %li.grand-child
--#                       %h4
--#                       = grandchild[:name]
+.header-category-list
+  - @categories.each do |parent| 
+    - if parent[:ancestry] == nil
+      %ul.parent-wrap
+        %li.parent
+          %h4.parent-category
+            = parent[:name]
+          %ul.child-wrap
+            - parent.children.each do |child|
+              %li.child
+                %h4
+                  = child[:name]
+                %ul.grand-child-wrap
+                  - child.children.each do |grandchild|
+                    %li.grand-child
+                      %h4
+                      = grandchild[:name]


### PR DESCRIPTION
# What
カテゴリーボックスの修正及び、エラーの解消

# Why
子要素、孫要素にカーソルが当たった場合に色をつけるため
また、商品詳細でエラーが起きていたため修正

<img width="826" alt="スクリーンショット 2019-08-24 16 07 10" src="https://user-images.githubusercontent.com/52589647/63633866-07ca5d80-c68a-11e9-9a40-538a1e54c48c.png">
