### PR TITLE
チーム開発、sns認証の導入の修正

### DIFF
--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -38,12 +38,12 @@
                 %div
                   = f.label :nickname, "ニックネーム"
                   %span.form-must 必須
-                = f.text_field :nickname, class: "text-default", placeholder: "例）メルカリ太郎"
+                = f.text_field :nickname, class: "text-default", placeholder: "例）メルカリ太郎",value: session[:nickname]
               .each-forms
                 %div
                   = f.label :email, "メールアドレス"
                   %span.form-must 必須
-                = f.text_field :email, class: "text-default", placeholder: "PC・携帯どちらでも可"
+                = f.text_field :email, class: "text-default", placeholder: "PC・携帯どちらでも可",value: session[:email]
               .each-forms
                 %div
                   = f.label :password, "パスワード"


### PR DESCRIPTION
# What
コントローラーで読み込んだ値を新規登録フォームに表示する記述が抜けていた為、修正した。
(ローカルのみ、本番環境で動作するようには実装していません。)
# Why
sns認証が正常に上手くいっているか確認する為。